### PR TITLE
feat: profile api init &  refactor: jwt storage module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@
 /dist
 /node_modules
 /build
-/https
 
 # Logs
 logs/

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -62,6 +62,7 @@ export default [
             { pattern: '#profile/**', group: 'internal', position: 'before' },
             { pattern: '#lesson/**', group: 'internal', position: 'before' },
             { pattern: '#direct-lesson/**', group: 'internal', position: 'before' },
+            { pattern: '#trainer/**', group: 'internal', position: 'before' },
             { pattern: '#quote/**', group: 'internal', position: 'before' },
             { pattern: '#review/**', group: 'internal', position: 'before' },
             { pattern: '#notification/**', group: 'internal', position: 'before' },

--- a/https/auth.http
+++ b/https/auth.http
@@ -1,0 +1,41 @@
+###
+// user 회원가입
+POST http://localhost:3000/auth/signUp/user
+Content-Type: application/json
+
+{
+  "nickname": "test12",
+  "email": "test12@example.com",
+  "password": "testpassword12!"
+}
+
+###
+// trainer 회원가입
+POST http://localhost:3000/auth/signUp/trainer
+Content-Type: application/json
+
+{
+  "nickname": "test13",
+  "email": "test13@example.com",
+  "password": "testpassword13!"
+}
+
+###
+// 로그인
+POST http://localhost:3000/auth/login
+Content-Type: application/json
+
+{
+  "email": "test5@example.com",
+  "password": "testpassword5!"
+}
+
+###
+// access token 재발급
+POST http://localhost:3000/auth/token/refresh
+Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOiI0NTg1YjY0MC02OTBmLTRhY2YtYWUyZS1hZGM3Zjk1N2M2MGMiLCJyb2xlIjoiVVNFUiIsImlhdCI6MTczNjI5NzUwNiwiZXhwIjoxNzM2MzAxMTA2fQ.t3zHamdeiA1eW7HLiSIAy67pPwGvjtRRj_PhgjYymjM
+
+###
+// user 단일 조회하기
+GET http://localhost:3000/users/4585b640-690f-4acf-ae2e-adc7f957c60c
+Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOiI0NTg1YjY0MC02OTBmLTRhY2YtYWUyZS1hZGM3Zjk1N2M2MGMiLCJyb2xlIjoiVVNFUiIsImlhdCI6MTczNjI2OTMzNCwiZXhwIjoxNzM3NDc4OTM0fQ.Y81e4FlGxUcO1JTtn6Ev5IPaFTn0PHJILOGCetj8G4k

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "#profile/*": "./dist/src/profile/*",
     "#lesson/*": "./dist/src/lesson/*",
     "#direct-lesson/*": "./dist/src/direct-lesson/*",
+    "#trainer/*": "./dist/src/trainer/*",
     "#quote/*": "./dist/src/quote/*",
     "#review/*": "./dist/src/review/*",
     "#notification/*": "./dist/src/notification/*",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -6,6 +6,7 @@ import { AlsModule } from '#common/als/als.module.js';
 import { AuthModule } from '#auth/auth.module.js';
 import { AccessTokenGuard } from '#auth/guard/access-token.guard.js';
 import { UserModule } from '#user/user.module.js';
+import { ProfileModule } from '#profile/profile.module.js';
 
 @Module({
   imports: [
@@ -17,6 +18,7 @@ import { UserModule } from '#user/user.module.js';
     AlsModule,
     AuthModule,
     UserModule,
+    ProfileModule,
   ],
   controllers: [],
   providers: [AccessTokenGuard],

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -3,20 +3,19 @@ import { AuthGuard } from '@nestjs/passport';
 import { AuthService } from '#auth/auth.service.js';
 import { ReqUser } from '#auth/decorator/user.decorator.js';
 import { RefreshTokenGuard } from '#auth/guard/refresh-token.guard.js';
-import { InputCreateUserDTO } from '#auth/type/auth.dto.js';
-import { Payload } from '#auth/type/auth.type.js';
+import { CreateUserDTO } from '#auth/type/auth.dto.js';
 
 @Controller('auth')
 export class AuthController {
   constructor(private readonly authService: AuthService) {}
 
   @Post('signup/user')
-  async createUser(@Body() body: InputCreateUserDTO) {
+  async createUser(@Body() body: CreateUserDTO) {
     return await this.authService.createUser({ ...body, role: 'USER' });
   }
 
   @Post('signup/trainer')
-  async createTrainer(@Body() body: InputCreateUserDTO) {
+  async createTrainer(@Body() body: CreateUserDTO) {
     return await this.authService.createUser({ ...body, role: 'TRAINER' });
   }
 

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -3,12 +3,12 @@ import { ConfigModule, ConfigService } from '@nestjs/config';
 import { JwtModule } from '@nestjs/jwt';
 import { PassportModule } from '@nestjs/passport';
 import { PrismaModule } from '#prisma/prisma.module.js';
+import { JwtConfigModule } from '#common/jwt.module.js';
 import { AuthController } from '#auth/auth.controller.js';
 import { AuthService } from '#auth/auth.service.js';
 import { LocalStrategy } from '#auth/strategy/local.strategy.js';
 import { RefreshTokenStrategy } from '#auth/strategy/refresh-token.strategy.js';
 import { UserRepository } from '#user/user.repository.js';
-import { TOKEN_EXPIRATION } from '#configs/jwt.config.js';
 
 @Module({
   imports: [
@@ -17,17 +17,10 @@ import { TOKEN_EXPIRATION } from '#configs/jwt.config.js';
       isGlobal: true,
     }),
     PassportModule.register({ defaultStrategy: 'local' }),
-    JwtModule.registerAsync({
-      imports: [ConfigModule],
-      inject: [ConfigService],
-      useFactory: async (configService: ConfigService) => ({
-        secret: configService.get<string>('JWT_SECRET'),
-        signOptions: { expiresIn: TOKEN_EXPIRATION.REFRESH },
-      }),
-    }),
+    JwtConfigModule,
   ],
   controllers: [AuthController],
   providers: [AuthService, LocalStrategy, RefreshTokenStrategy, UserRepository],
-  exports: [JwtModule],
+  exports: [],
 })
 export class AuthModule {}

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
-import { UserEmailNotFoundException, UserExistsException } from '#exception/http-exception.js';
+import { UserEmailNotFound, UserExistsException } from '#exception/http-exception.js';
 import { InvalidRefreshToken } from '#exception/http-exception.js';
 import { IAuthService } from '#auth/interface/auth.service.interface.js';
 import type { CreateUser, FilterUser } from '#auth/type/auth.type';
@@ -32,7 +32,7 @@ export class AuthService implements IAuthService {
 
   async getUser(email: string, password: string): Promise<FilterUser> {
     const user = await this.userRepository.findByEmail(email);
-    if (!user) throw new UserEmailNotFoundException();
+    if (!user) throw new UserEmailNotFound();
     verifyPassword(password, user.password);
     return filterSensitiveUserData(user);
   }

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -3,7 +3,7 @@ import { JwtService } from '@nestjs/jwt';
 import { UserEmailNotFoundException, UserExistsException } from '#exception/http-exception.js';
 import { InvalidRefreshToken } from '#exception/http-exception.js';
 import { IAuthService } from '#auth/interface/auth.service.interface.js';
-import { CreateUser, FilterUser } from '#auth/type/auth.type';
+import type { CreateUser, FilterUser } from '#auth/type/auth.type';
 import { UserRepository } from '#user/user.repository.js';
 import { TOKEN_EXPIRATION } from '#configs/jwt.config.js';
 import { filterSensitiveUserData } from '#utils/filter-sensitive-user-data.js';

--- a/src/auth/guard/access-token.guard.ts
+++ b/src/auth/guard/access-token.guard.ts
@@ -28,8 +28,6 @@ export class AccessTokenGuard implements CanActivate {
       if (store) {
         store.userId = decoded.userId;
         store.userRole = decoded.role;
-        console.log(store.userId); //추후 삭제
-        console.log(store.userRole); //추후 삭제
       }
 
       return true;

--- a/src/auth/interface/auth.service.interface.ts
+++ b/src/auth/interface/auth.service.interface.ts
@@ -1,5 +1,5 @@
-import { CreateUser } from '#auth/type/auth.type.js';
-import { FilterUser } from '#auth/type/auth.type.js';
+import type { CreateUser } from '#auth/type/auth.type.js';
+import type { FilterUser } from '#auth/type/auth.type.js';
 
 export interface IAuthService {
   createUser(data: CreateUser): Promise<FilterUser>;

--- a/src/auth/strategy/local.strategy.ts
+++ b/src/auth/strategy/local.strategy.ts
@@ -4,7 +4,7 @@ import { validateOrReject } from 'class-validator';
 import { Strategy } from 'passport-local';
 import { WrongFormatException } from '#exception/http-exception.js';
 import { AuthService } from '#auth/auth.service.js';
-import { InputSignInDTO } from '#auth/type/auth.dto.js';
+import { LoginDTO } from '#auth/type/auth.dto.js';
 
 @Injectable()
 export class LocalStrategy extends PassportStrategy(Strategy) {
@@ -13,7 +13,7 @@ export class LocalStrategy extends PassportStrategy(Strategy) {
   }
 
   async validate(email: string, password: string) {
-    const signInDto = new InputSignInDTO();
+    const signInDto = new LoginDTO();
     signInDto.email = email;
     signInDto.password = password;
 

--- a/src/auth/strategy/local.strategy.ts
+++ b/src/auth/strategy/local.strategy.ts
@@ -2,7 +2,7 @@ import { Injectable, UnauthorizedException } from '@nestjs/common';
 import { PassportStrategy } from '@nestjs/passport';
 import { validateOrReject } from 'class-validator';
 import { Strategy } from 'passport-local';
-import { WrongFormatException } from '#exception/http-exception.js';
+import { WrongFormat } from '#exception/http-exception.js';
 import { AuthService } from '#auth/auth.service.js';
 import { LoginDTO } from '#auth/type/auth.dto.js';
 
@@ -20,7 +20,7 @@ export class LocalStrategy extends PassportStrategy(Strategy) {
     try {
       await validateOrReject(signInDto);
     } catch (e) {
-      throw new WrongFormatException();
+      throw new WrongFormat();
     }
 
     const user = await this.authService.getUser(email, password);

--- a/src/auth/strategy/refresh-token.strategy.ts
+++ b/src/auth/strategy/refresh-token.strategy.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { PassportStrategy } from '@nestjs/passport';
-import { Request } from 'express';
+import type { Request } from 'express';
 import { ExtractJwt, Strategy } from 'passport-jwt';
 import { NoRefreshToken } from '#exception/http-exception.js';
 import type { Payload } from '#auth/type/auth.type.js';

--- a/src/auth/type/auth.dto.ts
+++ b/src/auth/type/auth.dto.ts
@@ -1,7 +1,6 @@
-import { Role } from '@prisma/client';
-import { IsNotEmpty, IsOptional, IsString, IsEmail, Matches, IsEnum } from 'class-validator';
+import { IsNotEmpty, IsString, IsEmail, Matches } from 'class-validator';
 
-export class InputCreateUserDTO {
+export class CreateUserDTO {
   @IsNotEmpty()
   @IsString()
   nickname: string;
@@ -17,7 +16,7 @@ export class InputCreateUserDTO {
   password: string;
 }
 
-export class InputSignInDTO {
+export class LoginDTO {
   @IsNotEmpty()
   @IsString()
   email: string;

--- a/src/common/als/als.module.ts
+++ b/src/common/als/als.module.ts
@@ -1,6 +1,7 @@
 import { Module, Global } from '@nestjs/common';
 import { AsyncLocalStorage } from 'async_hooks';
 import { IAsyncLocalStorage } from '#common/als/als.type.js';
+import { AlsStore } from '#common/als/store-validator.js';
 
 @Global()
 @Module({
@@ -9,7 +10,12 @@ import { IAsyncLocalStorage } from '#common/als/als.type.js';
       provide: AsyncLocalStorage,
       useValue: new AsyncLocalStorage<IAsyncLocalStorage>(),
     },
+    {
+      provide: AlsStore,
+      useFactory: (als: AsyncLocalStorage<IAsyncLocalStorage>) => new AlsStore(als),
+      inject: [AsyncLocalStorage],
+    },
   ],
-  exports: [AsyncLocalStorage],
+  exports: [AsyncLocalStorage, AlsStore],
 })
 export class AlsModule {}

--- a/src/common/jwt.module.ts
+++ b/src/common/jwt.module.ts
@@ -1,0 +1,20 @@
+import { Module, Global } from '@nestjs/common';
+import { ConfigModule, ConfigService } from '@nestjs/config';
+import { JwtModule, JwtModuleOptions } from '@nestjs/jwt';
+import { TOKEN_EXPIRATION } from '#configs/jwt.config.js';
+
+@Global()
+@Module({
+  imports: [
+    JwtModule.registerAsync({
+      imports: [ConfigModule],
+      useFactory: async (configService: ConfigService): Promise<JwtModuleOptions> => ({
+        secret: configService.get<string>('JWT_SECRET'),
+        signOptions: { expiresIn: TOKEN_EXPIRATION.REFRESH },
+      }),
+      inject: [ConfigService],
+    }),
+  ],
+  exports: [JwtModule],
+})
+export class JwtConfigModule {}

--- a/src/exception/exception-message.ts
+++ b/src/exception/exception-message.ts
@@ -13,6 +13,7 @@ enum ExceptionMessages {
   INVALID_REFRESH_TOKEN = '유효하지 않은 리프레시 토큰입니다.',
   INVALID_ACCESS_TOKEN = '유효하지 않은 엑세스 토큰입니다.',
   NO_STORE = '활성화된 AsyncLocalStorage 컨텍스트를 찾을 수 없습니다.',
+  PROFILE_NOT_FOUND = '해당 프로필을 찾을 수 없습니다.',
 }
 
 export default ExceptionMessages;

--- a/src/exception/http-exception.ts
+++ b/src/exception/http-exception.ts
@@ -23,3 +23,4 @@ export const NoRefreshToken: ExceptionConstructor = customHttpException(Exceptio
 export const InvalidRefreshToken: ExceptionConstructor = customHttpException(ExceptionMessages.INVALID_REFRESH_TOKEN, HttpStatus.UNAUTHORIZED);
 export const NoStoreException: ExceptionConstructor = customHttpException(ExceptionMessages.NO_STORE, HttpStatus.INTERNAL_SERVER_ERROR);
 export const ForbiddenException: ExceptionConstructor = customHttpException(ExceptionMessages.FORBIDDEN, HttpStatus.FORBIDDEN);
+export const ProfileNotFound: ExceptionConstructor = customHttpException(ExceptionMessages.PROFILE_NOT_FOUND, HttpStatus.NOT_FOUND);

--- a/src/exception/http-exception.ts
+++ b/src/exception/http-exception.ts
@@ -12,13 +12,13 @@ export function customHttpException(message: string, status: HttpStatus): Except
 }
 
 export const BadRequestException: ExceptionConstructor = customHttpException(ExceptionMessages.BAD_REQUEST, HttpStatus.BAD_REQUEST);
-export const UserNotFoundException: ExceptionConstructor = customHttpException(ExceptionMessages.USER_NOT_FOUND, HttpStatus.NOT_FOUND);
+export const UserNotFound: ExceptionConstructor = customHttpException(ExceptionMessages.USER_NOT_FOUND, HttpStatus.NOT_FOUND);
 export const UserExistsException: ExceptionConstructor = customHttpException(ExceptionMessages.USER_EXISTS, HttpStatus.CONFLICT);
-export const UserEmailNotFoundException: ExceptionConstructor = customHttpException(ExceptionMessages.EMAIL_NOT_FOUND, HttpStatus.NOT_FOUND);
-export const PasswordErrorException: ExceptionConstructor = customHttpException(ExceptionMessages.PASSWORD_ERROR, HttpStatus.BAD_REQUEST);
-export const NoEnvVariableException: ExceptionConstructor = customHttpException(ExceptionMessages.NO_ENV_VARIABLE, HttpStatus.INTERNAL_SERVER_ERROR);
+export const UserEmailNotFound: ExceptionConstructor = customHttpException(ExceptionMessages.EMAIL_NOT_FOUND, HttpStatus.NOT_FOUND);
+export const PasswordError: ExceptionConstructor = customHttpException(ExceptionMessages.PASSWORD_ERROR, HttpStatus.BAD_REQUEST);
+export const NoEnvVariable: ExceptionConstructor = customHttpException(ExceptionMessages.NO_ENV_VARIABLE, HttpStatus.INTERNAL_SERVER_ERROR);
 export const UnauthorizedException: ExceptionConstructor = customHttpException(ExceptionMessages.UNAUTHORIZED, HttpStatus.UNAUTHORIZED);
-export const WrongFormatException: ExceptionConstructor = customHttpException(ExceptionMessages.WRONG_FORMAT, HttpStatus.BAD_REQUEST);
+export const WrongFormat: ExceptionConstructor = customHttpException(ExceptionMessages.WRONG_FORMAT, HttpStatus.BAD_REQUEST);
 export const NoRefreshToken: ExceptionConstructor = customHttpException(ExceptionMessages.NO_REFRESH_TOKEN, HttpStatus.NOT_FOUND);
 export const InvalidRefreshToken: ExceptionConstructor = customHttpException(ExceptionMessages.INVALID_REFRESH_TOKEN, HttpStatus.UNAUTHORIZED);
 export const NoStoreException: ExceptionConstructor = customHttpException(ExceptionMessages.NO_STORE, HttpStatus.INTERNAL_SERVER_ERROR);

--- a/src/profile/interface/profile.repository.interface.ts
+++ b/src/profile/interface/profile.repository.interface.ts
@@ -1,0 +1,8 @@
+import type { Profile } from '@prisma/client';
+import type { CreateProfile, UpdateProfile } from '#profile/type/profile.type.js';
+
+export interface IProfileRepository {
+  findProfileById(id: string): Promise<Profile | null>;
+  createProfile(data: CreateProfile): Promise<Profile>;
+  updateProfile(id: string, data: UpdateProfile): Promise<Profile>;
+}

--- a/src/profile/interface/profile.service.interface.ts
+++ b/src/profile/interface/profile.service.interface.ts
@@ -1,0 +1,7 @@
+import type { Profile } from '@prisma/client';
+import type { CreateProfile, UpdateProfile } from '#profile/type/profile.type.js';
+export interface IProfileService {
+  createProfile(data: CreateProfile): Promise<Profile>;
+  findProfileById(id: string): Promise<Profile>;
+  updateProfile(id: string, data: UpdateProfile): Promise<Profile>;
+}

--- a/src/profile/profile.controller.ts
+++ b/src/profile/profile.controller.ts
@@ -1,5 +1,6 @@
-import { Controller, Get, Post, Body, Patch, Param, Delete } from '@nestjs/common';
+import { Controller, Get, Post, Body, Patch, Param, Delete, UseGuards } from '@nestjs/common';
 import { UUIDPipe } from '#common/uuid.pipe.js';
+import { AccessTokenGuard } from '#auth/guard/access-token.guard.js';
 import { ProfileService } from '#profile/profile.service.js';
 import { CreateProfileDTO, UpdateProfileDTO } from '#profile/type/profile.dto.js';
 
@@ -8,6 +9,7 @@ export class ProfileController {
   constructor(private readonly profileService: ProfileService) {}
 
   @Post()
+  @UseGuards(AccessTokenGuard)
   postProfile(@Body() body: CreateProfileDTO) {
     return this.profileService.createProfile(body);
   }

--- a/src/profile/profile.controller.ts
+++ b/src/profile/profile.controller.ts
@@ -1,0 +1,24 @@
+import { Controller, Get, Post, Body, Patch, Param, Delete } from '@nestjs/common';
+import { UUIDPipe } from '#common/uuid.pipe.js';
+import { ProfileService } from '#profile/profile.service.js';
+import { CreateProfileDTO, UpdateProfileDTO } from '#profile/type/profile.dto.js';
+
+@Controller('profile')
+export class ProfileController {
+  constructor(private readonly profileService: ProfileService) {}
+
+  @Post()
+  postProfile(@Body() body: CreateProfileDTO) {
+    return this.profileService.createProfile(body);
+  }
+
+  @Get(':id')
+  getProfileById(@Param('id', UUIDPipe) id: string) {
+    return this.profileService.findProfileById(id);
+  }
+
+  @Patch(':id')
+  patchProfile(@Param('id', UUIDPipe) id: string, @Body() body: UpdateProfileDTO) {
+    return this.profileService.updateProfile(id, body);
+  }
+}

--- a/src/profile/profile.module.ts
+++ b/src/profile/profile.module.ts
@@ -1,12 +1,26 @@
 import { Module } from '@nestjs/common';
+import { AsyncLocalStorage } from 'async_hooks';
 import { PrismaModule } from '#prisma/prisma.module.js';
+import { AlsModule } from '#common/als/als.module.js';
+import { IAsyncLocalStorage } from '#common/als/als.type.js';
+import { AlsStore } from '#common/als/store-validator.js';
+import { AccessTokenGuard } from '#auth/guard/access-token.guard.js';
 import { ProfileController } from '#profile/profile.controller.js';
 import { ProfileRepository } from '#profile/profile.repository.js';
 import { ProfileService } from '#profile/profile.service.js';
 
 @Module({
-  imports: [PrismaModule],
+  imports: [PrismaModule, AlsModule],
   controllers: [ProfileController],
-  providers: [ProfileService, ProfileRepository],
+  providers: [
+    AccessTokenGuard,
+    {
+      provide: AlsStore,
+      useFactory: (als: AsyncLocalStorage<IAsyncLocalStorage>) => new AlsStore(als),
+      inject: [AsyncLocalStorage],
+    },
+    ProfileService,
+    ProfileRepository,
+  ],
 })
 export class ProfileModule {}

--- a/src/profile/profile.module.ts
+++ b/src/profile/profile.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { PrismaModule } from '#prisma/prisma.module.js';
+import { ProfileController } from '#profile/profile.controller.js';
+import { ProfileRepository } from '#profile/profile.repository.js';
+import { ProfileService } from '#profile/profile.service.js';
+
+@Module({
+  imports: [PrismaModule],
+  controllers: [ProfileController],
+  providers: [ProfileService, ProfileRepository],
+})
+export class ProfileModule {}

--- a/src/profile/profile.repository.ts
+++ b/src/profile/profile.repository.ts
@@ -1,10 +1,11 @@
 import { Injectable } from '@nestjs/common';
 import type { Profile } from '@prisma/client';
 import { PrismaService } from '#prisma/prisma.service.js';
+import { IProfileRepository } from '#profile/interface/profile.repository.interface.js';
 import type { CreateProfile, UpdateProfile } from '#profile/type/profile.type.js';
 
 @Injectable()
-export class ProfileRepository {
+export class ProfileRepository implements IProfileRepository {
   private readonly profile;
 
   constructor(private readonly prisma: PrismaService) {

--- a/src/profile/profile.repository.ts
+++ b/src/profile/profile.repository.ts
@@ -1,0 +1,32 @@
+import { Injectable } from '@nestjs/common';
+import type { Profile } from '@prisma/client';
+import { PrismaService } from '#prisma/prisma.service.js';
+import type { CreateProfile, UpdateProfile } from '#profile/type/profile.type.js';
+
+@Injectable()
+export class ProfileRepository {
+  private readonly profile;
+
+  constructor(private readonly prisma: PrismaService) {
+    this.profile = prisma.profile;
+  }
+
+  async findProfileById(id: string): Promise<Profile | null> {
+    return await this.profile.findUnique({
+      where: { id },
+    });
+  }
+
+  async createProfile(data: CreateProfile): Promise<Profile> {
+    return await this.profile.create({
+      data,
+    });
+  }
+
+  async updateProfile(id: string, data: UpdateProfile): Promise<Profile> {
+    return await this.profile.update({
+      where: { id },
+      data,
+    });
+  }
+}

--- a/src/profile/profile.service.ts
+++ b/src/profile/profile.service.ts
@@ -1,0 +1,26 @@
+import { Injectable } from '@nestjs/common';
+import type { Profile } from '@prisma/client';
+import { ProfileNotFound } from '#exception/http-exception.js';
+import { ProfileRepository } from '#profile/profile.repository.js';
+import type { CreateProfile, UpdateProfile } from '#profile/type/profile.type.js';
+
+@Injectable()
+export class ProfileService {
+  constructor(private readonly profileRepository: ProfileRepository) {}
+
+  async createProfile(data: CreateProfile): Promise<Profile> {
+    return await this.profileRepository.createProfile(data);
+  }
+
+  async findProfileById(id: string): Promise<Profile> {
+    const profile = await this.profileRepository.findProfileById(id);
+    if (!profile) throw new ProfileNotFound();
+    return profile;
+  }
+
+  async updateProfile(id: string, data: UpdateProfile): Promise<Profile> {
+    const profile = await this.profileRepository.findProfileById(id);
+    if (!profile) throw new ProfileNotFound();
+    return await this.profileRepository.updateProfile(id, data);
+  }
+}

--- a/src/profile/profile.service.ts
+++ b/src/profile/profile.service.ts
@@ -1,11 +1,12 @@
 import { Injectable } from '@nestjs/common';
 import type { Profile } from '@prisma/client';
 import { ProfileNotFound } from '#exception/http-exception.js';
+import { IProfileService } from '#profile/interface/profile.service.interface.js';
 import { ProfileRepository } from '#profile/profile.repository.js';
 import type { CreateProfile, UpdateProfile } from '#profile/type/profile.type.js';
 
 @Injectable()
-export class ProfileService {
+export class ProfileService implements IProfileService {
   constructor(private readonly profileRepository: ProfileRepository) {}
 
   async createProfile(data: CreateProfile): Promise<Profile> {

--- a/src/profile/type/profile.dto.ts
+++ b/src/profile/type/profile.dto.ts
@@ -1,0 +1,48 @@
+import { PartialType } from '@nestjs/mapped-types';
+import { Gender, LessonType, Region } from '@prisma/client';
+import { IsString, IsOptional, IsNotEmpty, IsArray, IsEnum, IsInt, Min } from 'class-validator';
+
+export class CreateProfileDTO {
+  @IsString()
+  @IsNotEmpty()
+  userId: string;
+  @IsString()
+  @IsOptional()
+  name?: string;
+
+  @IsString()
+  @IsOptional()
+  profileImage?: string;
+  @IsString()
+  @IsOptional()
+  phone?: string;
+  @IsEnum(Gender)
+  gender: Gender;
+
+  @IsArray()
+  @IsEnum(LessonType, { each: true })
+  lessonType: LessonType[];
+
+  @IsArray()
+  @IsEnum(Region, { each: true })
+  region: Region[];
+
+  @IsString()
+  @IsOptional()
+  intro?: string;
+
+  @IsString()
+  @IsOptional()
+  description?: string;
+
+  @IsInt()
+  @Min(0)
+  @IsOptional()
+  experience?: number;
+
+  @IsString()
+  @IsOptional()
+  certification?: string;
+}
+
+export class UpdateProfileDTO extends PartialType(CreateProfileDTO) {}

--- a/src/profile/type/profile.dto.ts
+++ b/src/profile/type/profile.dto.ts
@@ -6,6 +6,7 @@ export class CreateProfileDTO {
   @IsString()
   @IsNotEmpty()
   userId: string;
+
   @IsString()
   @IsOptional()
   name?: string;
@@ -13,9 +14,11 @@ export class CreateProfileDTO {
   @IsString()
   @IsOptional()
   profileImage?: string;
+
   @IsString()
   @IsOptional()
   phone?: string;
+
   @IsEnum(Gender)
   gender: Gender;
 

--- a/src/profile/type/profile.type.ts
+++ b/src/profile/type/profile.type.ts
@@ -1,0 +1,18 @@
+import { PartialType } from '@nestjs/mapped-types';
+import { Gender, LessonType, Region } from '@prisma/client';
+
+export class CreateProfile {
+  userId: string;
+  name?: string;
+  profileImage?: string;
+  phone?: string;
+  gender: Gender;
+  lessonType: LessonType[];
+  region: Region[];
+  intro?: string;
+  description?: string;
+  experience?: number;
+  certification?: string;
+}
+
+export class UpdateProfile extends PartialType(CreateProfile) {}

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -1,6 +1,4 @@
 import { Controller, Get, Param, UseGuards } from '@nestjs/common';
-import { AsyncLocalStorage } from 'async_hooks';
-import { IAsyncLocalStorage } from '#common/als/als.type.js';
 import { AlsStore } from '#common/als/store-validator.js';
 import { UUIDPipe } from '#common/uuid.pipe.js';
 import { ForbiddenException } from '#exception/http-exception.js';

--- a/src/user/user.module.ts
+++ b/src/user/user.module.ts
@@ -1,9 +1,6 @@
 import { Module } from '@nestjs/common';
-import { AsyncLocalStorage } from 'async_hooks';
 import { PrismaModule } from '#prisma/prisma.module.js';
 import { AlsModule } from '#common/als/als.module.js';
-import { IAsyncLocalStorage } from '#common/als/als.type.js';
-import { AlsStore } from '#common/als/store-validator.js';
 import { AuthModule } from '#auth/auth.module.js';
 import { AccessTokenGuard } from '#auth/guard/access-token.guard.js';
 import { UserController } from '#user/user.controller.js';
@@ -13,16 +10,7 @@ import { UserService } from '#user/user.service.js';
 @Module({
   imports: [PrismaModule, AuthModule, AlsModule],
   controllers: [UserController],
-  providers: [
-    UserService,
-    UserRepository,
-    AccessTokenGuard,
-    {
-      provide: AlsStore,
-      useFactory: (als: AsyncLocalStorage<IAsyncLocalStorage>) => new AlsStore(als),
-      inject: [AsyncLocalStorage],
-    },
-  ],
+  providers: [UserService, UserRepository, AccessTokenGuard],
   exports: [UserRepository],
 })
 export class UserModule {}

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import { UserNotFoundException } from '#exception/http-exception.js';
+import { UserNotFound } from '#exception/http-exception.js';
 import type { FilterUser } from '#auth/type/auth.type.js';
 import { IUserService } from '#user/interface/user.service.interface.js';
 import { UserRepository } from '#user/user.repository.js';
@@ -10,7 +10,7 @@ export class UserService implements IUserService {
 
   async findUserById(id: string): Promise<FilterUser> {
     const user = await this.userRepository.findUserById(id);
-    if (!user) throw new UserNotFoundException();
+    if (!user) throw new UserNotFound();
     return user;
   }
 }

--- a/src/utils/hashing-password.ts
+++ b/src/utils/hashing-password.ts
@@ -1,5 +1,5 @@
 import bcrypt from 'bcrypt';
-import { PasswordErrorException } from '#exception/http-exception.js';
+import { PasswordError } from '#exception/http-exception.js';
 
 export async function hashingPassword(password: string) {
   return await bcrypt.hash(password, 10);
@@ -8,6 +8,6 @@ export async function hashingPassword(password: string) {
 export async function verifyPassword(password: string, encryptedPassword: string) {
   const isValid = await bcrypt.compare(password, encryptedPassword);
   if (!isValid) {
-    throw new PasswordErrorException();
+    throw new PasswordError();
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,6 +12,7 @@
       "#profile/*": ["./src/profile/*"],
       "#lesson/*": ["./src/lesson/*"],
       "#direct-lesson/*": ["./src/direct-lesson/*"],
+      "#trainer/*": ["./src/trainer/*"],
       "#quote/*": ["./src/quote/*"],
       "#review/*": ["./src/review/*"],
       "#notification/*": ["./src/notification/*"],


### PR DESCRIPTION
## 이슈 번호
- close #

## 작업 사항
- [x] 프로필 폴더 기초세팅, jwt storage 모듈 재정의

## 세부 작업 사항
- [x] 프로필 폴더 기초세팅
- [x]  jwt storage 모듈 재정의
- [x] trainer import 경로 추가

## 참고 사항
- async local storage를 사용할 때 반복되는 코드를 줄이기 위해서 module 코드를 다시 작성하였습니다
```
import { Module } from '@nestjs/common';
import { AlsModule } from '#common/als/als.module.js';
import { AccessTokenGuard } from '#auth/guard/access-token.guard.js';

@Module({
  imports: [AlsModule],
  controllers: [],
  providers: [AccessTokenGuard],
  exports: [],
})
export class UserModule {}
```
앞으로는 이렇게 AlsModule만 가져와서 @UseGuards(AccessTokenGuard) 사용 후  const { userId, userRole } = this.alsStore.getStore(); 사용하시면 됩니다

## 기타
