### PR TITLE
feat: add filter count to response and direct quote to query

### DIFF
--- a/src/lesson/dto/lesson.dto.ts
+++ b/src/lesson/dto/lesson.dto.ts
@@ -115,14 +115,18 @@ export class QueryLessonDto {
   gender?: Gender;
 
   @IsOptional()
-  @IsBoolean()
-  @Transform(({ value }) => value === 'false')
-  direct_quote_request?: boolean;
-
-  @IsOptional()
   @Transform(({ value }) => (value ? value.split(',') : []))
   @IsEnum(Region, { each: true, message: '유효하지 않은 지역입니다.' })
   region?: Region[];
+
+  @IsOptional()
+  @Transform(({ value }) => {
+    if (value === 'true') return true;
+    if (value === 'false') return false;
+    return value;
+  })
+  @IsBoolean({ message: 'has_direct_quote는 true 또는 false 값이어야 합니다.' })
+  has_direct_quote?: boolean;
 
   // CamelCase 변환 메서드
   toCamelCase() {
@@ -137,7 +141,7 @@ export class QueryLessonDto {
       locationType: this.location_type,
       status: this.status,
       gender: this.gender,
-      directQuoteRequest: this.direct_quote_request,
+      hasDirectQuote: this.has_direct_quote,
       region: this.region,
     };
   }

--- a/src/lesson/interface/lesson-repository.interface.ts
+++ b/src/lesson/interface/lesson-repository.interface.ts
@@ -1,4 +1,10 @@
-import type { DirectQuoteRequest, LessonRequest, LessonRequestStatus } from '@prisma/client';
+import type {
+  DirectQuoteRequest,
+  LessonRequest,
+  LessonRequestStatus,
+  LessonType,
+  Prisma,
+} from '@prisma/client';
 import type { CreateLesson, LessonResponse, PatchLesson } from '../type/lesson.type';
 
 export interface ILessonRepository {

--- a/src/lesson/interface/lesson-service.interface.ts
+++ b/src/lesson/interface/lesson-service.interface.ts
@@ -9,7 +9,19 @@ export interface ILessonService {
   getLessons(
     query: QueryLessonDto,
     userId?: string,
-  ): Promise<{ list: LessonResponse[]; totalCount: number; hasMore: boolean }>;
+  ): Promise<{
+    list: LessonResponse[];
+    totalCount: number;
+    hasMore: boolean;
+    lessonTypeCounts: Record<string, number>;
+    genderCounts: Record<string, number>;
+    directQuoteRequestCount : number;
+  }>;
+  getMyLessons(query: QueryLessonDto): Promise<{
+    list: LessonResponse[];
+    totalCount: number;
+    hasMore: boolean;
+  }>;
   createDirectQuoteRequest(lessonId: string, data: CreateDirectQuoteDto): Promise<DirectQuoteRequest>;
   updateLessonById(id: string, data: PatchLesson): Promise<LessonResponse>;
   updateLessonStatus(id: string, status: LessonRequestStatus): Promise<LessonResponse>;

--- a/src/lesson/lesson.repository.ts
+++ b/src/lesson/lesson.repository.ts
@@ -81,4 +81,51 @@ export class LessonRepository implements ILessonRepository {
   }): Promise<DirectQuoteRequest> {
     return await this.directQuoteRequest.create({ data });
   }
+
+  /**
+   * (where 조건 없이) 전체 레슨 데이터를 대상으로 lessonType을 groupBy
+   */
+  async groupByLessonTypeAll(): Promise<
+    {
+      lessonType: string; // 또는 LessonType
+      count: number;
+    }[]
+  > {
+    const results = await this.prisma.lessonRequest.groupBy({
+      by: ['lessonType'],
+      _count: {
+        lessonType: true,
+      },
+      // where: {} ← 명시 안 하면 전체 레코드 대상
+    });
+
+    // 반환값을 { lessonType, count } 형태로 가공
+    return results.map((item) => ({
+      lessonType: item.lessonType,
+      count: item._count.lessonType,
+    }));
+  }
+
+  // lesson.repository.ts (예시)
+  async findAllForGenderCount() {
+    return this.prisma.lessonRequest.findMany({
+      select: {
+        id: true,
+        user: {
+          select: {
+            profile: {
+              select: {
+                gender: true,
+              },
+            },
+          },
+        },
+        directQuoteRequests: {
+          select: {
+            trainerId: true, // 트레이너 ID만 필요
+          },
+        },
+      },
+    });
+  }
 }


### PR DESCRIPTION
## 이슈 번호

- close #57 이슈번호

## 작업 사항

- [x] 요청레슨에 대한 필터 카운트 추가

## 세부 작업 사항

- [x] 레슨 목록 응답에 필터(레슨타입, 성별, 지정견적 요청수) 카운트 추가
- [x] 레슨 목록 쿼리파라미터에 지정견적여부 추가

## 참고 사항

-[] 다른 팀원에게 알릴 내용이 있으면 작성해주세요.

## 기타
팀 노션의 API 명세서를 참조해주세요
