### PR TITLE
Feat/reject dqr

### DIFF
--- a/prisma/migrations/20250121091740_add_reject_reason_to_direct_quote_request/migration.sql
+++ b/prisma/migrations/20250121091740_add_reject_reason_to_direct_quote_request/migration.sql
@@ -1,0 +1,6 @@
+-- CreateEnum
+CREATE TYPE "DirectQuoteRequestStatus" AS ENUM ('PENDING', 'REJECTED');
+
+-- AlterTable
+ALTER TABLE "DirectQuoteRequest" ADD COLUMN     "rejectionReason" TEXT,
+ADD COLUMN     "status" "DirectQuoteRequestStatus" NOT NULL DEFAULT 'PENDING';

--- a/prisma/migrations/20250122021139_add_proposed_to_direct_quote_request_status/migration.sql
+++ b/prisma/migrations/20250122021139_add_proposed_to_direct_quote_request_status/migration.sql
@@ -1,0 +1,2 @@
+-- AlterEnum
+ALTER TYPE "DirectQuoteRequestStatus" ADD VALUE 'PROPOSED';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -96,11 +96,13 @@ model DirectQuoteRequest {
   id              String   @id @default(uuid())
   lessonRequestId String
   trainerId       String
+  status          DirectQuoteRequestStatus @default(PENDING)
+  rejectionReason String?
   createdAt       DateTime @default(now())
   updatedAt       DateTime @updatedAt
 
   lessonRequest LessonRequest @relation(fields: [lessonRequestId], references: [id], onDelete: Cascade)
-  instructor    User          @relation(fields: [trainerId], references: [id], onDelete: Cascade)
+  trainer         User          @relation(fields: [trainerId], references: [id], onDelete: Cascade)
 
   @@unique([lessonRequestId, trainerId])
 }
@@ -235,6 +237,11 @@ enum QuoteStatus {
   ACCEPTED
   REJECTED
   CANCELED
+}
+
+enum DirectQuoteRequestStatus {
+  PENDING  // 요청됨
+  REJECTED // 반려됨
 }
 
 enum NotificationType {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -242,6 +242,7 @@ enum QuoteStatus {
 enum DirectQuoteRequestStatus {
   PENDING  // 요청됨
   REJECTED // 반려됨
+  PROPOSED // 제안됨
 }
 
 enum NotificationType {

--- a/src/exception/lesson-exception-message.ts
+++ b/src/exception/lesson-exception-message.ts
@@ -8,6 +8,10 @@ enum LessonExceptionMessage {
   INVALID_LESSON_STATUS_FOR_QUOTE = '대기중인 레슨에만 견적을 요청할 수 있습니다.',
   TRAINER_NOT_FOUND_OR_INVALID = '해당 트레이너가 존재하지 않습니다.',
   DIRECT_QUOTE_ALREADY_EXISTS = '이미 해당 트레이너에게 지정 견적 요청이 존재합니다..',
+  DIRECT_QUOTE_NOT_FOUND = '지정 견적 요청을 찾을 수 없습니다.',
+  NOT_MY_DIRECT_QUOTE_REQUEST = '본인의 지정 견적 요청만 반려할 수 있습니다.',
+  INVALID_DIRECT_QUOTE_STATUS = '이미 처리된 요청입니다.',
+  INVALID_LESSON_REQUEST_MATCH = '요청 레슨과 지정 견적 요청이 일치하지 않습니다.',
 }
 
 export default LessonExceptionMessage;

--- a/src/lesson/dto/lesson.dto.ts
+++ b/src/lesson/dto/lesson.dto.ts
@@ -152,3 +152,9 @@ export class CreateDirectQuoteDto {
   @IsUUID('4', { message: '유효하지 않은 강사 ID입니다.' })
   trainerId: string;
 }
+
+export class RejectDirectQuoteDto {
+  @IsNotEmpty()
+  @IsString()
+  rejectionReason: string;
+}

--- a/src/lesson/lesson.controller.ts
+++ b/src/lesson/lesson.controller.ts
@@ -1,7 +1,12 @@
 import { Controller, Get, Post, Body, Patch, Param, UseGuards, Query } from '@nestjs/common';
 import { UUIDPipe } from '#common/uuid.pipe.js';
 import { AccessTokenGuard } from '#auth/guard/access-token.guard.js';
-import { CreateDirectQuoteDto, CreateLessonDto, QueryLessonDto } from './dto/lesson.dto.js';
+import {
+  CreateDirectQuoteDto,
+  CreateLessonDto,
+  QueryLessonDto,
+  RejectDirectQuoteDto,
+} from './dto/lesson.dto.js';
 import { LessonService } from './lesson.service.js';
 
 @Controller('lessons')
@@ -66,5 +71,18 @@ export class LessonController {
   @UseGuards(AccessTokenGuard)
   async createDirectQuote(@Param('id', UUIDPipe) lessonId: string, @Body() body: CreateDirectQuoteDto) {
     return this.lessonService.createDirectQuoteRequest(lessonId, body);
+  }
+  /*************************************************************************************
+   * 지정 견적 요청에 대한 반려
+   * ***********************************************************************************
+   */
+  @Patch(':lessonId/direct_quote/:directQuoteRequestId/reject')
+  @UseGuards(AccessTokenGuard)
+  async rejectDirectQuoteRequest(
+    @Param('lessonId', UUIDPipe) lessonId: string,
+    @Param('directQuoteRequestId', UUIDPipe) directQuoteRequestId: string,
+    @Body() body: RejectDirectQuoteDto,
+  ) {
+    return this.lessonService.rejectDirectQuoteRequest(lessonId, directQuoteRequestId, body);
   }
 }

--- a/src/lesson/lesson.repository.ts
+++ b/src/lesson/lesson.repository.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import { DirectQuoteRequest, LessonRequest, LessonRequestStatus, Prisma } from '@prisma/client';
+import { DirectQuoteRequest, DirectQuoteRequestStatus, LessonRequest, LessonRequestStatus, Prisma } from '@prisma/client';
 import { PrismaService } from '#prisma/prisma.service.js';
 import { ILessonRepository } from './interface/lesson-repository.interface.js';
 import { CreateLesson, LessonResponse, PatchLesson } from './type/lesson.type.js';
@@ -75,11 +75,25 @@ export class LessonRepository implements ILessonRepository {
     });
   }
 
+  // 지정 견적 요청 생성
   async createDirectQuoteRequest(data: {
     lessonRequestId: string;
     trainerId: string;
   }): Promise<DirectQuoteRequest> {
     return await this.directQuoteRequest.create({ data });
+  }
+
+  // 지정 견적 요청 반려를 위한 조회
+  async findDirectQuoteRequestById(id: string): Promise<DirectQuoteRequest | null> {
+    return await this.directQuoteRequest.findUnique({ where: { id } });
+  }
+
+  // 지정 견적 요청 반려
+  async updateDirectQuoteRequest(
+    id: string,
+    data: { status: DirectQuoteRequestStatus; rejectionReason?: string },
+  ): Promise<DirectQuoteRequest> {
+    return await this.directQuoteRequest.update({ where: { id }, data });
   }
 
   /**
@@ -106,7 +120,7 @@ export class LessonRepository implements ILessonRepository {
     }));
   }
 
-  // lesson.repository.ts (예시)
+  // 남/여 카운트 계산을 위한 조회회
   async findAllForGenderCount() {
     return this.prisma.lessonRequest.findMany({
       select: {

--- a/src/lesson/lesson.service.ts
+++ b/src/lesson/lesson.service.ts
@@ -196,7 +196,10 @@ export class LessonService implements ILessonService {
       updatedAt: true,
       directQuoteRequests: {
         select: {
+          lessonRequestId: true,
           trainerId: true,
+          status: true,
+          rejectionReason: true,
         },
       },
       user: {
@@ -400,19 +403,19 @@ export class LessonService implements ILessonService {
     const directQuoteRequest = await this.lessonRepository.findDirectQuoteRequestById(directQuoteRequestId);
 
     if (!directQuoteRequest) {
-      throw new NotFoundException('지정 견적 요청을 찾을 수 없습니다.');
+      throw new NotFoundException(LessonExceptionMessage.DIRECT_QUOTE_NOT_FOUND);
     }
 
     if (directQuoteRequest.trainerId != trainerId) {
-      throw new UnauthorizedException('본인의 지정 견적 요청만 반려할 수 있습니다.');
+      throw new UnauthorizedException(LessonExceptionMessage.NOT_MY_DIRECT_QUOTE_REQUEST);
     }
 
     if (directQuoteRequest.lessonRequestId != lessonId) {
-      throw new BadRequestException('잘못된 요청입니다.');
+      throw new BadRequestException(LessonExceptionMessage.INVALID_LESSON_REQUEST_MATCH);
     }
 
     if (directQuoteRequest.status != 'PENDING') {
-      throw new BadRequestException('이미 처리된 요청입니다다');
+      throw new BadRequestException(LessonExceptionMessage.INVALID_DIRECT_QUOTE_STATUS);
     }
 
     return await this.lessonRepository.updateDirectQuoteRequest(directQuoteRequestId, {


### PR DESCRIPTION
## 이슈 번호

- close #65 이슈번호

## 작업 사항

- [X] 지정견적 요청에 대한 반려기능

## 세부 작업 사항

- [x] 지정견적 요청에 대한 반려기능
- [x] 요청 레슨 목록 응답에 지정견적 관련 추가 필드 포함
- [x] 지정 견적 요청 관련 상태값 추가(
```
enum DirectQuoteRequestStatus {
  PENDING  // 요청됨
  REJECTED // 반려됨
  PROPOSED // 제안됨
}
```
## 참고 사항

-[] 다른 팀원에게 알릴 내용이 있으면 작성해주세요.
* 상태값 추가에 따른 마이그레이션 필요

## 기타
변경된 응답 내용은 팀 노션의 API 명세서를 참조해 주세요