### PR TITLE
feat: include quote infomation in my lessons response

### DIFF
--- a/prisma/mock/lesson_quote.mock.ts
+++ b/prisma/mock/lesson_quote.mock.ts
@@ -67,6 +67,23 @@ export const LESSON_QUOTES = [
     createdAt: new Date('2025-01-13T06:31:51.060Z'),
     updatedAt: new Date('2025-01-13T06:31:51.060Z'),
   },
+
+
+
+  {
+    id: '1a1f489c0-a951-44c4-8d52-bec26edf0ccd',
+    trainerId: '11752641-132b-4ec3-ab67-bb2116cc3c94',
+    lessonRequestId: '399fc386-d1a7-4430-a37d-9d1c5bdafd03',
+    price: 130000.0,
+    message: 'trainer01 완료된 레슨.',
+    status: QuoteStatus.ACCEPTED,
+    rejectionReason: null,
+    createdAt: new Date('2025-01-17T06:30:12.460Z'),
+    updatedAt: new Date('2025-01-17T06:30:12.460Z'),
+  },  
+
+
+
   {
     id: '8df489c0-a951-44c4-8d52-bec26edf0ccd',
     trainerId: '11752641-132b-4ec3-ab67-bb2116cc3c94',

--- a/src/lesson/lesson.service.ts
+++ b/src/lesson/lesson.service.ts
@@ -213,6 +213,30 @@ export class LessonService implements ILessonService {
           rejectionReason: true,
         },
       },
+      lessonQuotes: {
+        select: {
+          id: true,
+          lessonRequestId: true,
+          trainerId: true,
+          price: true,
+          status: true,
+          createdAt: true,
+          updatedAt: true,
+          rejectionReason: true,
+          trainer: {
+            select: {
+              id: true,
+              nickname: true,
+              profile: {
+                select: {
+                  name: true,
+                  region: true,
+                },
+              },
+            },
+          },
+        },
+      },
       user: {
         select: {
           id: true,


### PR DESCRIPTION
## 이슈 번호

- close #79 이슈번호

## 작업 사항

- [x] 레슨목록 응답에 견정 정보 포함하기

## 세부 작업 사항

- [x] 레슨목록 응답에 견정 정보 포함하기
- [x] mock data 수정

## 참고 사항

-[x] 다른 팀원에게 알릴 내용이 있으면 작성해주세요.
* 프론트 요청에 의해서 급하게 수정 되는 부분이라 service 에서 select 부분은 1월 31일 리팩토링하겠습니다.

## 기타
`npm run seed` 수행 필요