### PR TITLE
fix: delete chat logic

### DIFF
--- a/src/chat/chat.controller.ts
+++ b/src/chat/chat.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Post, Param, Body, Query, UseGuards } from '@nestjs/common';
+import { Controller, Get, Post, Param, Body, Query, UseGuards, Delete } from '@nestjs/common';
 import { AccessTokenGuard } from '#auth/guard/access-token.guard.js';
 import { ChatService } from './chat.service.js';
 import { CreateChatDto, GetMessagesQueryDto, GetMyChatRoomsQueryDto } from './dto/chat.dto.js';
@@ -36,7 +36,7 @@ export class ChatController {
   }
 
   // 5. 채팅방 나가기
-  @Post('leave/:roomId')
+  @Delete('leave/:roomId')
   @UseGuards(AccessTokenGuard)
   async leaveChatRoom(@Param('roomId') roomId: string) {
     await this.chatService.leaveChatRoom(roomId);

--- a/src/chat/chat.repository.ts
+++ b/src/chat/chat.repository.ts
@@ -56,4 +56,13 @@ export class ChatRepository implements IChatRepository {
       ],
     });
   }
+
+  async updateParticipantLeft(roomId: string, participant: 'participant1' | 'participant2'): Promise<void> {
+    await this.chatRoomModel.updateOne({ roomId }, { $set: { [`left_${participant}`]: true } });
+  }
+
+  async deleteChatRoom(roomId: string): Promise<void> {
+    await this.chatModel.deleteMany({ roomId });
+    await this.chatRoomModel.deleteOne({ roomId });
+  }
 }

--- a/src/chat/chatRoom.schema.ts
+++ b/src/chat/chatRoom.schema.ts
@@ -11,6 +11,12 @@ export class ChatRoom extends Document {
 
   @Prop({ required: true }) // 채팅 상대방
   participant2: string;
+
+  @Prop({ default: false }) // participant1의 나가기 여부
+  left_participant1: boolean;
+
+  @Prop({ default: false }) // participant2의 나가기 여부
+  left_participant2: boolean;
 }
 
 export const ChatRoomSchema = SchemaFactory.createForClass(ChatRoom);

--- a/src/chat/interface/chat.repository.interface.ts
+++ b/src/chat/interface/chat.repository.interface.ts
@@ -9,4 +9,6 @@ export interface IChatRepository {
   createChatRoom(data: Partial<ChatRoom>): Promise<ChatRoom>;
   deleteMessagesByUser(roomId: string, userId: string): Promise<void>;
   findChatRoomByParticipants(participant1: string, participant2: string): Promise<ChatRoom | null>;
+  updateParticipantLeft(roomId: string, userId: string): Promise<void>;
+  deleteChatRoom(roomId: string): Promise<void>;
 }

--- a/src/exception/chat-exception-message.ts
+++ b/src/exception/chat-exception-message.ts
@@ -5,6 +5,7 @@ enum ChatExceptionMessage {
   MESSAGE_SAVE_FAILED = '메시지 저장에 실패했습니다.',
   CHAT_ROOM_LIST_FAILED = '채팅방 목록을 불러오는 중 오류가 발생했습니다.',
   INVALID_PAGE_OR_LIMIT = '페이지 또는 제한 값이 잘못되었습니다.',
+  DELETED_CHAT_ROOM = '삭제된 채팅방입니다.',
 }
 
 export default ChatExceptionMessage;


### PR DESCRIPTION
## 이슈 번호

- close #146 

## 작업 사항

- [x] 채팅 삭제 로직 수정

## 세부 작업 사항

- [x] 기존의 채팅 삭제시 한쪽이 삭제를 하면 전체가 아닌 해당 유저의 부분만 삭제되던 기능을 A가 삭제하면 A만 해당 채팅방과 채팅내역에서 제외되고 B는 기존의 채팅기록과 채팅방을 볼 수 있고 B또한 삭제시 채팅방과 기록 모두 삭제가 되게 수정함

