### PR TITLE
Fix/adjust notification timezone and improve notifications

### DIFF
--- a/prisma/migrations/20250203091557_add_notification_sp_trigger/migration.sql
+++ b/prisma/migrations/20250203091557_add_notification_sp_trigger/migration.sql
@@ -15,12 +15,14 @@ BEGIN
     "userId", 
     "type", 
     "message",
+    "createdAt",
     "updatedAt"
   ) VALUES (
     user_id, 
     type::"NotificationType",   -- 문자열을 enum으로 변환
     message,
-    now() -- DB 내부에서 updatedAt은 수동으로 셋팅해줘야 함
+    now() AT TIME ZONE 'UTC', -- UTC 기준으로 변환하여 저장장
+    now() AT TIME ZONE 'UTC' -- DB 내부에서 updatedAt은 수동으로 셋팅해줘야 함
   );
 END;
 $$;

--- a/prisma/migrations/20250203091557_add_notification_sp_trigger/migration.sql
+++ b/prisma/migrations/20250203091557_add_notification_sp_trigger/migration.sql
@@ -104,16 +104,16 @@ BEGIN
   -- 상태에 따른 알림 메시지 생성
   CASE lesson_status
     WHEN 'QUOTE_CONFIRMED' THEN
-      notification_message := user_nick || '님의 레슨(' || lesson_sub_type_kr || ')에 대한 견적이 확정되었습니다.';
+      notification_message := user_nick || '님의 [' || lesson_type_kr || ' - ' || lesson_sub_type_kr || '] 레슨에 대한 견적이 확정되었습니다.';
 
     WHEN 'COMPLETED' THEN
-      notification_message := user_nick || '님의 레슨(' || lesson_sub_type_kr || ')이 완료되었습니다.';
+      notification_message := user_nick || '님의 [' || lesson_type_kr || ' - ' || lesson_sub_type_kr || '] 레슨이 완료되었습니다.';
 
     WHEN 'CANCELED' THEN
-      notification_message := user_nick || '님의 레슨(' || lesson_type_kr || ' - ' || lesson_sub_type_kr || ') 요청이 취소되었습니다.';
+      notification_message := user_nick || '님의 [' || lesson_type_kr || ' - ' || lesson_sub_type_kr || '] 레슨 요청이 취소되었습니다.';
 
     WHEN 'EXPIRED' THEN
-      notification_message := user_nick || '님의 레슨(' || lesson_sub_type_kr || ') 요청이 만료되었습니다.';
+      notification_message := user_nick || '님의 [' || lesson_type_kr || ' - ' || lesson_sub_type_kr || '] 레슨 요청이 만료되었습니다.';
     ELSE
       RETURN; -- 알림을 보낼 필요가 없는 상태이면 종료
   END CASE;
@@ -364,21 +364,23 @@ DECLARE
   trainer_id TEXT;
   lesson_type "LessonType";
   location_type "LocationType";
+  lesson_sub_type "LessonSubType";
   start_date DATE;
   end_date DATE;
   requester_nick TEXT;
   notification_message TEXT;
   lesson_type_kr TEXT;
+  lesson_sub_type_kr TEXT;
   location_type_kr TEXT;
   road_address TEXT;
 
 BEGIN
   -- 새로운 레슨 요청의 정보 가져오기
-  SELECT lr."lessonType", lr."locationType", 
+  SELECT lr."lessonType", lr."lessonSubType", lr."locationType", 
     lr."startDate" AT TIME ZONE 'UTC' AT TIME ZONE 'Asia/Seoul', 
     lr."endDate" AT TIME ZONE 'UTC' AT TIME ZONE 'Asia/Seoul', 
     lr."roadAddress", u."nickname"
-  INTO lesson_type, location_type, start_date, end_date, road_address, requester_nick
+  INTO lesson_type, lesson_sub_type, location_type, start_date, end_date, road_address, requester_nick
   FROM "LessonRequest" lr
   JOIN "User" u ON lr."userId" = u."id"
   WHERE lr.id = lesson_id;
@@ -389,6 +391,28 @@ BEGIN
     WHEN 'FITNESS' THEN lesson_type_kr := '피트니스';
     WHEN 'REHAB' THEN lesson_type_kr := '재활';
     ELSE lesson_type_kr := '기타';
+  END CASE;
+
+  -- lesson_sub_type을 한글로 변환
+  CASE lesson_sub_type
+    WHEN 'SOCCER' THEN lesson_sub_type_kr := '축구';
+    WHEN 'BASKETBALL' THEN lesson_sub_type_kr := '농구';
+    WHEN 'BASEBALL' THEN lesson_sub_type_kr := '야구';
+    WHEN 'TENNIS' THEN lesson_sub_type_kr := '테니스';
+    WHEN 'BADMINTON' THEN lesson_sub_type_kr := '배드민턴';
+    WHEN 'TABLE_TENNIS' THEN lesson_sub_type_kr := '탁구';
+    WHEN 'SKI' THEN lesson_sub_type_kr := '스키';
+    WHEN 'SURFING' THEN lesson_sub_type_kr := '서핑';
+    WHEN 'BOXING' THEN lesson_sub_type_kr := '복싱';
+    WHEN 'TAEKWONDO' THEN lesson_sub_type_kr := '태권도';
+    WHEN 'JIUJITSU' THEN lesson_sub_type_kr := '주짓수';
+    WHEN 'PERSONAL_TRAINING' THEN lesson_sub_type_kr := '퍼스널 트레이닝';
+    WHEN 'YOGA' THEN lesson_sub_type_kr := '요가';
+    WHEN 'PILATES' THEN lesson_sub_type_kr := '필라테스';
+    WHEN 'DIET_MANAGEMENT' THEN lesson_sub_type_kr := '다이어트 관리';
+    WHEN 'STRETCHING' THEN lesson_sub_type_kr := '스트레칭';
+    WHEN 'REHAB_TREATMENT' THEN lesson_sub_type_kr := '재활 치료';
+    ELSE lesson_sub_type_kr := lesson_type_kr;
   END CASE;
 
   -- location_type에 따라 한글로 변환(OFFLINE 일 경우 해당 지역 표시)
@@ -415,7 +439,7 @@ BEGIN
 
   LOOP
     -- 알림 메시지 생성
-    notification_message := requester_nick || '님이 [' || location_type_kr || ']에서 ' || start_date || ' ~ ' || end_date || ' 동안 [' || lesson_type_kr || '] 레슨을 요청했습니다.';
+    notification_message := requester_nick || '님이 [' || location_type_kr || ']에서 ' || start_date || ' ~ ' || end_date || ' 동안 [' || lesson_type_kr || ' - ' || lesson_sub_type_kr || '] 레슨을 요청했습니다.';
 
     -- 트레이너에게 알림 전송
     CALL notify_user_change(

--- a/prisma/migrations/20250203091557_add_notification_sp_trigger/migration.sql
+++ b/prisma/migrations/20250203091557_add_notification_sp_trigger/migration.sql
@@ -355,7 +355,10 @@ DECLARE
 
 BEGIN
   -- 새로운 레슨 요청의 정보 가져오기
-  SELECT lr."lessonType", lr."locationType", lr."startDate", lr."endDate", lr."roadAddress", u."nickname"
+  SELECT lr."lessonType", lr."locationType", 
+    lr."startDate" AT TIME ZONE 'UTC' AT TIME ZONE 'Asia/Seoul', 
+    lr."endDate" AT TIME ZONE 'UTC' AT TIME ZONE 'Asia/Seoul', 
+    lr."roadAddress", u."nickname"
   INTO lesson_type, location_type, start_date, end_date, road_address, requester_nick
   FROM "LessonRequest" lr
   JOIN "User" u ON lr."userId" = u."id"
@@ -380,7 +383,7 @@ BEGIN
       location_type_kr := '오프라인';
     END IF;
   ELSE
-    location_type_kr := '기타타';
+    location_type_kr := '기타';
   END IF;
 
   -- 매칭되는 트레이너 찾기

--- a/prisma/migrations/20250203091557_add_notification_sp_trigger/migration.sql
+++ b/prisma/migrations/20250203091557_add_notification_sp_trigger/migration.sql
@@ -125,7 +125,7 @@ BEGIN
   );
 
   -- 트레이너 알림 생성 추가
-  IF lesson_status IN ('QUOTE_CONFIRMED', 'COMPLETED') THEN
+  IF lesson_status IN ('QUOTE_CONFIRMED', 'COMPLETED', 'CANCELED') THEN
     SELECT "trainerId"
     INTO trainer_id
     FROM "LessonQuote"

--- a/src/exception/lesson-exception-message.ts
+++ b/src/exception/lesson-exception-message.ts
@@ -14,6 +14,7 @@ enum LessonExceptionMessage {
   INVALID_LESSON_REQUEST_MATCH = '요청 레슨과 지정 견적 요청이 일치하지 않습니다.',
   DIRECT_QUOTE_LIMIT_REACHED = '지정 견적 요청은 최대 3개까지 가능합니다.',
   TRAINER_ALREADY_SENT_QUOTE = '이미 이 요청 레슨에 대해 견적서를 보냈습니다.',
+  INVALID_START_DATE = '레슨 시작일은 오늘 이후의 날짜이어야야 합니다.',
 }
 
 export default LessonExceptionMessage;

--- a/src/lesson/lesson.service.ts
+++ b/src/lesson/lesson.service.ts
@@ -47,6 +47,18 @@ export class LessonService implements ILessonService {
       throw new UnauthorizedException(LessonExceptionMessage.ONLY_USER_CAN_REQUEST_LESSON);
     }
 
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+
+    const startDate = new Date(data.startDate);
+    console.log('startDate', startDate);
+    console.log('today', today);
+
+    // 레슨 시작일이 오늘 이후이어야 함
+    if (startDate <= today) {
+      throw new BadRequestException(LessonExceptionMessage.INVALID_START_DATE);
+    }
+
     const [_user, pendingLesson] = await Promise.all([
       this.userService.findUserById(userId),
       this.lessonRepository.findLessonsByUserId(userId, LessonRequestStatus.PENDING),


### PR DESCRIPTION
## 이슈 번호

- close #이슈번호

## 작업 사항

- [x] 알림메시지 관련 시간 타임존 변경

## 세부 작업 사항

- [x] 트리거에서 생성할 때 UTC 로 변환해서 알림 삽입
- [x] SSE 알림 보낼때 KST 로 변환해서 전송
- [x] 알림 메시지를 작성할때 포함되는 날짜 기준을 KST 로 변환 
- [x] 레슨 요청 취소시에 트레이너에게 알림 전송 추가
- [x] 레슨 시작일을 요청일자 이후로 지정하도록 조건 추가
- [x] 알림 메시지 개선

## 참고 사항

-[] 다른 팀원에게 알릴 내용이 있으면 작성해주세요.
* `npx prisma migrate reset`, `npm run seed` 수행 필요

## 기타
